### PR TITLE
Update transrate container

### DIFF
--- a/modules/local/orp_transrate/Dockerfile
+++ b/modules/local/orp_transrate/Dockerfile
@@ -33,6 +33,3 @@ ENV PATH="/opt/orp-transrate:${PATH}"
 
 # Set working directory
 WORKDIR /opt/orp-transrate
-
-# Define entrypoint to ensure the image behaves predictably
-ENTRYPOINT ["/bin/bash"]

--- a/modules/local/orp_transrate/main.nf
+++ b/modules/local/orp_transrate/main.nf
@@ -5,7 +5,7 @@ process ORP_TRANSRATE {
     // Using conda or the biocontainer for transrate results in a SNAP index error.
     // However, the error does not occur when using the tarball from the Oyster River Protocol.
     // see https://github.com/blahah/transrate/issues/248
-    container 'docker://avanibhojwani/orp_transrate:1.0.3'
+    container 'docker.io/avanibhojwani/orp_transrate:1.0.3_cv1.2'
 
     input:
     tuple val(meta), path(fasta)         // assembly file


### PR DESCRIPTION

Previously, the container used for the local TransRate module was working with singularity profile, but not docker. Dockerfile and container were updated to fix this.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [N/A] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/denovotranscript/tree/master/.github/CONTRIBUTING.md)
- [N/A] If necessary, also make a PR on the nf-core/denovotranscript _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [N/A] Usage Documentation in `docs/usage.md` is updated.
- [N/A] Output Documentation in `docs/output.md` is updated.
- [N/A] `CHANGELOG.md` is updated.
- [N/A] `README.md` is updated (including new tool citations and authors/contributors).
