### PR TITLE
Fix skip_assembly

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -24,7 +24,7 @@ params {
 
     // Input data
     input  = 'https://raw.githubusercontent.com/nf-core/test-datasets/denovotranscript/samplesheet/samplesheet.csv'
-    transcript_fasta = 'https://raw.githubusercontent.com/nf-core/test-datasets/denovotranscript/data/minimal/assembled_mrna_2k.fasta'
+    transcript_fasta = 'https://raw.githubusercontent.com/nf-core/test-datasets/denovotranscript/data/minimal/assembled_mrna_2k.fa'
     busco_lineage = 'arthropoda_odb10'
     extra_fastp_args='--trim_front1 15 --trim_front2 15'
 

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -16,7 +16,7 @@ params {
 
     // Input data for full size test
     input  = 'https://raw.githubusercontent.com/nf-core/test-datasets/denovotranscript/samplesheet/samplesheet_full.csv'
-    transcript_fasta = 'https://raw.githubusercontent.com/nf-core/test-datasets/denovotranscript/data/full/assembled_mrna_80k.fasta'
+    transcript_fasta = 'https://raw.githubusercontent.com/nf-core/test-datasets/denovotranscript/data/full/assembled_mrna_80k.fa'
     busco_lineage = 'arthropoda_odb10'
     extra_fastp_args='--trim_front1 15 --trim_front2 15'
 

--- a/workflows/denovotranscript.nf
+++ b/workflows/denovotranscript.nf
@@ -252,9 +252,10 @@ workflow DENOVOTRANSCRIPT {
             }
         }
 
-        ch_transcripts_fa = ch_transcripts.collect { meta, fasta -> fasta }
         if (params.skip_assembly) {
-            ch_transcripts_fa = Channel.fromPath(params.transcripts_fa, checkIfExists: true)
+            ch_transcripts_fa = Channel.fromPath(params.transcript_fasta, checkIfExists: true)
+        } else {
+            ch_transcripts_fa = ch_transcripts.collect { meta, fasta -> fasta }
         }
 
         //


### PR DESCRIPTION
The --skip_assembly param was not working correctly due to errors in how ch_trancripts_fa was being defined. Changes made:
- updated `ch_transcripts_fa` in workflows/denovotranscript.nf
- corrected path to `--transcript_fasta` for test profiles

Test profiles now work with the `--skip_asembly` param.