### PR TITLE
Increase trinity resources

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -25,30 +25,32 @@ process {
     //        adding in your local modules too.
     // See https://www.nextflow.io/docs/latest/config.html#config-process-selectors
     withLabel:process_single {
-        cpus   = { 1                   }
-        memory = { 6.GB * task.attempt }
-        time   = { 4.h  * task.attempt }
+        cpus   = { 1                     }
+        memory = { 6.GB   * task.attempt }
+        time   = { 4.h    * task.attempt }
     }
     withLabel:process_low {
-        cpus   = { 2     * task.attempt }
-        memory = { 12.GB * task.attempt }
-        time   = { 4.h   * task.attempt }
+        cpus   = { 2      * task.attempt }
+        memory = { 12.GB  * task.attempt }
+        time   = { 4.h    * task.attempt }
     }
     withLabel:process_medium {
-        cpus   = { 6     * task.attempt }
-        memory = { 36.GB * task.attempt }
-        time   = { 8.h   * task.attempt }
+        cpus   = { 6      * task.attempt }
+        memory = { 36.GB  * task.attempt }
+        time   = { 8.h    * task.attempt }
     }
     withLabel:process_high {
-        cpus   = { 12    * task.attempt }
-        memory = { 72.GB * task.attempt }
-        time   = { 16.h  * task.attempt }
+        cpus   = { 12     * task.attempt }
+        memory = { 72.GB  * task.attempt }
+        time   = { 16.h   * task.attempt }
     }
     withLabel:process_long {
-        time   = { 20.h  * task.attempt }
+        time   = { 20.h   * task.attempt }
     }
     withLabel:process_high_memory {
-        memory = { 200.GB * task.attempt }
+        cpus   = { 20     * task.attempt }
+        memory = { 320.GB * task.attempt }
+        time   = { 200.h  * task.attempt }
     }
     withLabel:error_ignore {
         errorStrategy = 'ignore'

--- a/modules.json
+++ b/modules.json
@@ -8,99 +8,71 @@
                     "busco/busco": {
                         "branch": "master",
                         "git_sha": "17486961b8b1ab1aae258c83a7e947b40d8ab670",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "cat/cat": {
                         "branch": "master",
                         "git_sha": "9437e6053dccf4aafa022bfd6e7e9de67e625af8",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "cat/fastq": {
                         "branch": "master",
                         "git_sha": "4fc983ad0b30e6e32696fa7d980c76c7bfe1c03e",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "evigene/tr2aacds": {
                         "branch": "master",
                         "git_sha": "95d52841a6e2c6cd789dfd7248ac12a0fe4b5501",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "fastp": {
                         "branch": "master",
                         "git_sha": "95cf5fe0194c7bf5cb0e3027a2eb7e7c89385080",
-                        "installed_by": [
-                            "fastq_trim_fastp_fastqc",
-                            "modules"
-                        ]
+                        "installed_by": ["fastq_trim_fastp_fastqc", "modules"]
                     },
                     "fastqc": {
                         "branch": "master",
                         "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-                        "installed_by": [
-                            "fastq_trim_fastp_fastqc",
-                            "modules"
-                        ]
+                        "installed_by": ["fastq_trim_fastp_fastqc", "modules"]
                     },
                     "gawk": {
                         "branch": "master",
                         "git_sha": "cf3ed075695639b0a0924eb0901146df1996dc08",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "multiqc": {
                         "branch": "master",
                         "git_sha": "cf17ca47590cc578dfb47db1c2a44ef86f89976d",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "salmon/index": {
                         "branch": "master",
                         "git_sha": "cb6b2b94fc40dea58f0b1e3dd095f3dd24f2ac8a",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/salmon/index/salmon-index.diff"
                     },
                     "salmon/quant": {
                         "branch": "master",
                         "git_sha": "727232afb8294b53dd9d05bfe469b70cce1675bb",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/salmon/quant/salmon-quant.diff"
                     },
                     "sortmerna": {
                         "branch": "master",
                         "git_sha": "ad22467dff16284093e7335d5e77964e9bbc510b",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/sortmerna/sortmerna.diff"
                     },
                     "spades": {
                         "branch": "master",
                         "git_sha": "b3f04d8392f4571d5869eb3a345892dd2cbea225",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/spades/spades.diff"
                     },
                     "trinity": {
                         "branch": "master",
                         "git_sha": "e06c5f45395d6e34531257b125d410a298a3bd4f",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/trinity/trinity.diff"
                     }
                 }
@@ -110,30 +82,22 @@
                     "fastq_trim_fastp_fastqc": {
                         "branch": "master",
                         "git_sha": "cfd937a668919d948f6fcbf4218e79de50c2f36f",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     },
                     "utils_nextflow_pipeline": {
                         "branch": "master",
                         "git_sha": "3aa0aec1d52d492fe241919f0c6100ebf0074082",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     },
                     "utils_nfcore_pipeline": {
                         "branch": "master",
                         "git_sha": "1b6b9a3338d011367137808b49b923515080e3ba",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     },
                     "utils_nfschema_plugin": {
                         "branch": "master",
                         "git_sha": "bbd5a41f4535a8defafe6080e00ea74c45f4f96c",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     }
                 }
             }

--- a/modules.json
+++ b/modules.json
@@ -8,71 +8,99 @@
                     "busco/busco": {
                         "branch": "master",
                         "git_sha": "17486961b8b1ab1aae258c83a7e947b40d8ab670",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cat/cat": {
                         "branch": "master",
                         "git_sha": "9437e6053dccf4aafa022bfd6e7e9de67e625af8",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cat/fastq": {
                         "branch": "master",
                         "git_sha": "4fc983ad0b30e6e32696fa7d980c76c7bfe1c03e",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "evigene/tr2aacds": {
                         "branch": "master",
                         "git_sha": "95d52841a6e2c6cd789dfd7248ac12a0fe4b5501",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "fastp": {
                         "branch": "master",
                         "git_sha": "95cf5fe0194c7bf5cb0e3027a2eb7e7c89385080",
-                        "installed_by": ["fastq_trim_fastp_fastqc", "modules"]
+                        "installed_by": [
+                            "fastq_trim_fastp_fastqc",
+                            "modules"
+                        ]
                     },
                     "fastqc": {
                         "branch": "master",
                         "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-                        "installed_by": ["fastq_trim_fastp_fastqc", "modules"]
+                        "installed_by": [
+                            "fastq_trim_fastp_fastqc",
+                            "modules"
+                        ]
                     },
                     "gawk": {
                         "branch": "master",
                         "git_sha": "cf3ed075695639b0a0924eb0901146df1996dc08",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "multiqc": {
                         "branch": "master",
                         "git_sha": "cf17ca47590cc578dfb47db1c2a44ef86f89976d",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "salmon/index": {
                         "branch": "master",
                         "git_sha": "cb6b2b94fc40dea58f0b1e3dd095f3dd24f2ac8a",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/salmon/index/salmon-index.diff"
                     },
                     "salmon/quant": {
                         "branch": "master",
                         "git_sha": "727232afb8294b53dd9d05bfe469b70cce1675bb",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/salmon/quant/salmon-quant.diff"
                     },
                     "sortmerna": {
                         "branch": "master",
                         "git_sha": "ad22467dff16284093e7335d5e77964e9bbc510b",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/sortmerna/sortmerna.diff"
                     },
                     "spades": {
                         "branch": "master",
                         "git_sha": "b3f04d8392f4571d5869eb3a345892dd2cbea225",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/spades/spades.diff"
                     },
                     "trinity": {
                         "branch": "master",
                         "git_sha": "e06c5f45395d6e34531257b125d410a298a3bd4f",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/trinity/trinity.diff"
                     }
                 }
@@ -82,22 +110,30 @@
                     "fastq_trim_fastp_fastqc": {
                         "branch": "master",
                         "git_sha": "cfd937a668919d948f6fcbf4218e79de50c2f36f",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "utils_nextflow_pipeline": {
                         "branch": "master",
                         "git_sha": "3aa0aec1d52d492fe241919f0c6100ebf0074082",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "utils_nfcore_pipeline": {
                         "branch": "master",
                         "git_sha": "1b6b9a3338d011367137808b49b923515080e3ba",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "utils_nfschema_plugin": {
                         "branch": "master",
                         "git_sha": "bbd5a41f4535a8defafe6080e00ea74c45f4f96c",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     }
                 }
             }

--- a/modules/nf-core/trinity/main.nf
+++ b/modules/nf-core/trinity/main.nf
@@ -1,6 +1,5 @@
 process TRINITY {
     tag "$meta.id"
-    label 'process_high'
     label 'process_high_memory'
 
     conda "${moduleDir}/environment.yml"

--- a/modules/nf-core/trinity/trinity.diff
+++ b/modules/nf-core/trinity/trinity.diff
@@ -1,7 +1,15 @@
 Changes in module 'nf-core/trinity'
+Changes in 'trinity/main.nf':
 --- modules/nf-core/trinity/main.nf
 +++ modules/nf-core/trinity/main.nf
-@@ -9,7 +9,7 @@
+@@ -1,6 +1,5 @@
+ process TRINITY {
+     tag "$meta.id"
+-    label 'process_high'
+     label 'process_high_memory'
+ 
+     conda "${moduleDir}/environment.yml"
+@@ -9,7 +8,7 @@
          'biocontainers/trinity:2.15.1--pl5321h146fbdb_3' }"
  
      input:
@@ -11,4 +19,10 @@ Changes in module 'nf-core/trinity'
      output:
      tuple val(meta), path("*.fa.gz")    , emit: transcript_fasta
 
+'modules/nf-core/trinity/environment.yml' is unchanged
+'modules/nf-core/trinity/meta.yml' is unchanged
+'modules/nf-core/trinity/tests/tags.yml' is unchanged
+'modules/nf-core/trinity/tests/main.nf.test.snap' is unchanged
+'modules/nf-core/trinity/tests/nextflow.config' is unchanged
+'modules/nf-core/trinity/tests/main.nf.test' is unchanged
 ************************************************************


### PR DESCRIPTION
Increased resources for the Trinity module as this step often times out. 

Trinity [documentation ](https://github.com/trinityrnaseq/trinityrnaseq/wiki/Trinity-Computing-Requirements) suggests that for 1 M pairs of Illumina reads, you would need 1GB of memory and 0.5-1hr of time. 
For estimation purposes, based on samples on NCBI's SRA, I would say 1 sample=~30M paired reads. To make an assembly from 6 samples, 180GB memory and 90-180 hrs would seem like a reasonable amount of resources to try out.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [N/A] If you've fixed a bug or added code that should be tested, add tests!
- [N/A] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/denovotranscript/tree/master/.github/CONTRIBUTING.md)
- [X] If necessary, also make a PR on the nf-core/denovotranscript _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [N/A] Usage Documentation in `docs/usage.md` is updated.
- [N/A] Output Documentation in `docs/output.md` is updated.
- [N/A] `CHANGELOG.md` is updated.
- [N/A] `README.md` is updated (including new tool citations and authors/contributors).
