### PR TITLE
Fix Salmon quantification for skip_assembly mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Enhancements & fixes:
 
 - [PR #14](https://github.com/nf-core/denovotranscript/pull/14) - Template update for nf-core/tools v3.0.2
-- [PR #15](https://github.com/nf-core/denovotranscript/pull/16) - Fix logic for skip_assembly parameter
+- [PR #15](https://github.com/nf-core/denovotranscript/pull/15) - Fix logic for skip_assembly parameter
 - [PR #16](https://github.com/nf-core/denovotranscript/pull/16) - Increase resources for Trinity
+- [PR #19](https://github.com/nf-core/denovotranscript/pull/19) - Fix Salmon quantification when running in skip_assembly mode
 
 ## v1.0.0 - [2024-08-15]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Enhancements & fixes:
 - [PR #14](https://github.com/nf-core/denovotranscript/pull/14) - Template update for nf-core/tools v3.0.2
 - [PR #15](https://github.com/nf-core/denovotranscript/pull/15) - Fix logic for skip_assembly parameter
 - [PR #16](https://github.com/nf-core/denovotranscript/pull/16) - Increase resources for Trinity
-- [PR #19](https://github.com/nf-core/denovotranscript/pull/19) - Fix Salmon quantification when running in skip_assembly mode
+- [PR #19](https://github.com/nf-core/denovotranscript/pull/21) - Fix Salmon quantification when running in skip_assembly mode
 
 ## v1.0.0 - [2024-08-15]
 

--- a/workflows/denovotranscript.nf
+++ b/workflows/denovotranscript.nf
@@ -253,7 +253,7 @@ workflow DENOVOTRANSCRIPT {
         }
 
         if (params.skip_assembly) {
-            ch_transcripts_fa = Channel.fromPath(params.transcript_fasta, checkIfExists: true)
+            ch_transcripts_fa = params.transcript_fasta
         } else {
             ch_transcripts_fa = ch_transcripts.collect { meta, fasta -> fasta }
         }


### PR DESCRIPTION
When using skip_assembly mode, a transcript_fasta needs to be provided. The way this param was being used to create a channel for input to salmon_quant module has been changed. Previously, only one tuple of reads was being processed by salmon_quant, Now, all samples can be processed. Issue and solution is better explained here [https://bioinformatics.stackexchange.com/questions/20686/why-does-this-nextflow-script-finish-after-running-one-sample](https://bioinformatics.stackexchange.com/questions/20686/why-does-this-nextflow-script-finish-after-running-one-sample).

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [N/A] If you've fixed a bug or added code that should be tested, add tests!
- [N/A] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/denovotranscript/tree/master/.github/CONTRIBUTING.md)
- [N/A] If necessary, also make a PR on the nf-core/denovotranscript _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [N/A] Usage Documentation in `docs/usage.md` is updated.
- [N/A] Output Documentation in `docs/output.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [N/A] `README.md` is updated (including new tool citations and authors/contributors).
