### PR TITLE
Update spades resources and usage instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v1.2.0dev - [2024-11-29]
 
 - [PR #25](https://github.com/nf-core/denovotranscript/pull/25) - Bump version to 1.2.0dev
+- [PR #27](https://github.com/nf-core/denovotranscript/pull/27) - Update spades resources and usage instructions
 
 ## v1.1.0 - [2024-11-28]
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -41,7 +41,7 @@ process {
     }
     withLabel:process_high {
         cpus   = { 24     * task.attempt }
-        memory = { 144.GB  * task.attempt }
+        memory = { 144.GB * task.attempt }
         time   = { 32.h   * task.attempt }
     }
     withLabel:process_long {

--- a/conf/base.config
+++ b/conf/base.config
@@ -40,9 +40,9 @@ process {
         time   = { 8.h    * task.attempt }
     }
     withLabel:process_high {
-        cpus   = { 12     * task.attempt }
-        memory = { 72.GB  * task.attempt }
-        time   = { 16.h   * task.attempt }
+        cpus   = { 24     * task.attempt }
+        memory = { 144.GB  * task.attempt }
+        time   = { 32.h   * task.attempt }
     }
     withLabel:process_long {
         time   = { 20.h   * task.attempt }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -145,8 +145,9 @@
                 },
                 "ss": {
                     "type": "string",
-                    "description": "Set strand-specific type for rnaSPAdes. Use `--ss rf` when first read in pair corresponds to reverse gene strand (antisense data, e.g. obtained via dUTP protocol) and `--ss fr` otherwise (forward).",
-                    "help_text": "Note, that strand-specificity is not related and should not be confused with FR and RF orientation of paired reads. RNA-Seq paired-end reads typically have forward-reverse orientation (--> <--), which is assumed by default and no additional options are needed."
+                    "description": "Set strand-specific type for rnaSPAdes. Use `rf` when first read in pair corresponds to reverse gene strand (antisense data, e.g. obtained via dUTP protocol) and `fr` otherwise (forward).",
+                    "help_text": "Note, that strand-specificity is not related and should not be confused with FR and RF orientation of paired reads. RNA-Seq paired-end reads typically have forward-reverse orientation (--> <--), which is assumed by default and no additional options are needed.",
+                    "enum": ["rf", "fr"]
                 },
                 "extra_tr2aacds_args": {
                     "type": "string",


### PR DESCRIPTION
Increased resources for `process_high` which is used by the spades module to address issues #19 and #22. The main issue seems to be caused by memory running out. 

Edited description for the `ss` param available for the spades module because current instructions are confusing for users that are launching the workflow from a GUI, rather than a command line (#23).

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/denovotranscript/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/denovotranscript _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core pipelines lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
