### PR TITLE
Fix ch_transcripts and ch_pubids for AWS

### DIFF
--- a/.github/workflows/awstest.yml
+++ b/.github/workflows/awstest.yml
@@ -22,6 +22,7 @@ jobs:
           parameters: |
             {
               "outdir": "s3://${{ secrets.AWS_S3_BUCKET }}/denovotranscript/results-test-${{ github.sha }}"
+              "resume": "a77b287d-3e7d-464e-95e8-9a6b23d9537c"
             }
           profiles: test
 

--- a/.github/workflows/awstest.yml
+++ b/.github/workflows/awstest.yml
@@ -22,7 +22,6 @@ jobs:
           parameters: |
             {
               "outdir": "s3://${{ secrets.AWS_S3_BUCKET }}/denovotranscript/results-test-${{ github.sha }}",
-              "resume": "a77b287d-3e7d-464e-95e8-9a6b23d9537c"
             }
           profiles: test
 

--- a/.github/workflows/awstest.yml
+++ b/.github/workflows/awstest.yml
@@ -21,7 +21,7 @@ jobs:
           workdir: s3://${{ secrets.AWS_S3_BUCKET }}/work/denovotranscript/work-${{ github.sha }}
           parameters: |
             {
-              "outdir": "s3://${{ secrets.AWS_S3_BUCKET }}/denovotranscript/results-test-${{ github.sha }}",
+              "outdir": "s3://${{ secrets.AWS_S3_BUCKET }}/denovotranscript/results-test-${{ github.sha }}"
             }
           profiles: test
 

--- a/.github/workflows/awstest.yml
+++ b/.github/workflows/awstest.yml
@@ -24,6 +24,7 @@ jobs:
               "outdir": "s3://${{ secrets.AWS_S3_BUCKET }}/denovotranscript/results-test-${{ github.sha }}",
             }
           profiles: test
+          resume: 9efbe7f0-d32c-45a9-b4a5-05c474a2643d
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/awstest.yml
+++ b/.github/workflows/awstest.yml
@@ -24,7 +24,6 @@ jobs:
               "outdir": "s3://${{ secrets.AWS_S3_BUCKET }}/denovotranscript/results-test-${{ github.sha }}",
             }
           profiles: test
-          resume: 9efbe7f0-d32c-45a9-b4a5-05c474a2643d
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/awstest.yml
+++ b/.github/workflows/awstest.yml
@@ -21,7 +21,7 @@ jobs:
           workdir: s3://${{ secrets.AWS_S3_BUCKET }}/work/denovotranscript/work-${{ github.sha }}
           parameters: |
             {
-              "outdir": "s3://${{ secrets.AWS_S3_BUCKET }}/denovotranscript/results-test-${{ github.sha }}"
+              "outdir": "s3://${{ secrets.AWS_S3_BUCKET }}/denovotranscript/results-test-${{ github.sha }}",
               "resume": "a77b287d-3e7d-464e-95e8-9a6b23d9537c"
             }
           profiles: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #27](https://github.com/nf-core/denovotranscript/pull/27) - Update spades resources and usage instructions
 - [PR #28](https://github.com/nf-core/denovotranscript/pull/28) - Template update for nf-core/tools v3.1.0
 - [PR #29](https://github.com/nf-core/denovotranscript/pull/29) - Template update for nf-core/tools v3.1.1
+- [PR #30](https://github.com/nf-core/denovotranscript/pull/30) - Fix ch_transcripts and ch_pubids for AWS
 
 ## v1.1.0 - [2024-11-28]
 

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -10,6 +10,15 @@
 ----------------------------------------------------------------------------------------
 */
 
+process {
+    resourceLimits = [
+        cpus: 20,
+        memory: '200.GB',
+        time: '20.h'
+    ]
+    maxRetries    = 1
+}
+
 params {
     config_profile_name        = 'Full test profile'
     config_profile_description = 'Full test dataset to check pipeline function'

--- a/modules/local/orp_transrate/main.nf
+++ b/modules/local/orp_transrate/main.nf
@@ -34,6 +34,11 @@ process ORP_TRANSRATE {
     gunzip -c ${reads[0]} > ${prefix}_1.fq
     gunzip -c ${reads[1]} > ${prefix}_2.fq
 
+    mkdir ./tmp
+    export TMPDIR=./tmp
+    export TEMP=./tmp
+    export TMP=./tmp
+
     transrate \\
         --assembly $fasta \\
         --left ${prefix}_1.fq \\

--- a/modules/local/orp_transrate/main.nf
+++ b/modules/local/orp_transrate/main.nf
@@ -34,6 +34,7 @@ process ORP_TRANSRATE {
     gunzip -c ${reads[0]} > ${prefix}_1.fq
     gunzip -c ${reads[1]} > ${prefix}_2.fq
 
+    # Ruby (a dependency of transrate) requires a writable tmp directory
     mkdir ./tmp
     export TMPDIR=./tmp
     export TEMP=./tmp

--- a/workflows/denovotranscript.nf
+++ b/workflows/denovotranscript.nf
@@ -202,19 +202,15 @@ workflow DENOVOTRANSCRIPT {
             ch_versions = ch_versions.mix(EVIGENE_TR2AACDS.out.versions)
 
             ch_transcripts = EVIGENE_TR2AACDS.out.okayset.map { meta, dir ->
-                def mrna_file = file("${dir}/all_assembled.okay.mrna", checkIfExists: true, type: 'file')
-                return [ meta, mrna_file ]}
-            ch_transcripts.view()
-            ch_transcripts.ifEmpty {
-                error "ch_transcripts is empty!"
+                def mrna_file = dir.listFiles().find { it.name.endsWith('.okay.mrna') }
+                if (!mrna_file) throw new Exception("No .okay.mrna file found in ${dir}")
+                return [ meta, mrna_file ]
             }
 
             ch_pubids = EVIGENE_TR2AACDS.out.okayset.map { meta, dir ->
-                def pubids_file = file("${dir}/all_assembled.pubids", checkIfExists: true, type: 'file')
-                return [ meta, pubids_file ]}
-            ch_pubids.view()
-            ch_pubids.ifEmpty {
-                error "ch_pubids is empty!"
+                def pubids_file = dir.listFiles().find { it.name.endsWith('.pubids') }
+                if (!pubids_file) throw new Exception("No .pubids file found in ${dir}")
+                return [ meta, pubids_file ]
             }
             //
             // MODULE: TX2GENE

--- a/workflows/denovotranscript.nf
+++ b/workflows/denovotranscript.nf
@@ -202,7 +202,7 @@ workflow DENOVOTRANSCRIPT {
             ch_versions = ch_versions.mix(EVIGENE_TR2AACDS.out.versions)
 
             ch_transcripts = EVIGENE_TR2AACDS.out.okayset.map { meta, dir ->
-                def mrna_file = file("${dir}/*okay.mrna", checkIfExists: true, type: 'file')
+                def mrna_file = file("${dir}/all_assembled.okay.mrna", checkIfExists: true, type: 'file')
                 return [ meta, mrna_file ]}
             ch_transcripts.view()
             ch_transcripts.ifEmpty {
@@ -210,7 +210,7 @@ workflow DENOVOTRANSCRIPT {
             }
 
             ch_pubids = EVIGENE_TR2AACDS.out.okayset.map { meta, dir ->
-                def pubids_file = file("${dir}/*.pubids", checkIfExists: true, type: 'file')
+                def pubids_file = file("${dir}/all_assembled.pubids", checkIfExists: true, type: 'file')
                 return [ meta, pubids_file ]}
             ch_pubids.view()
             ch_pubids.ifEmpty {

--- a/workflows/denovotranscript.nf
+++ b/workflows/denovotranscript.nf
@@ -202,11 +202,11 @@ workflow DENOVOTRANSCRIPT {
             ch_versions = ch_versions.mix(EVIGENE_TR2AACDS.out.versions)
 
             ch_transcripts = EVIGENE_TR2AACDS.out.okayset.map { meta, dir ->
-                def mrna_file = file("$dir/*okay.mrna")
+                def mrna_file = file("${dir}/*okay.mrna", checkIfExists: true)
                 return [ meta, mrna_file ]}
 
             ch_pubids = EVIGENE_TR2AACDS.out.okayset.map { meta, dir ->
-                def pubids_file = file("$dir/*.pubids")
+                def pubids_file = file("${dir}/*.pubids", checkIfExists: true)
                 return [ meta, pubids_file ]}
             //
             // MODULE: TX2GENE

--- a/workflows/denovotranscript.nf
+++ b/workflows/denovotranscript.nf
@@ -202,12 +202,20 @@ workflow DENOVOTRANSCRIPT {
             ch_versions = ch_versions.mix(EVIGENE_TR2AACDS.out.versions)
 
             ch_transcripts = EVIGENE_TR2AACDS.out.okayset.map { meta, dir ->
-                def mrna_file = file("${dir}/*okay.mrna", checkIfExists: true)
+                def mrna_file = file("${dir}/*okay.mrna", checkIfExists: true, type: 'file')
                 return [ meta, mrna_file ]}
+            ch_transcripts.view()
+            ch_transcripts.ifEmpty {
+                error "ch_transcripts is empty!"
+            }
 
             ch_pubids = EVIGENE_TR2AACDS.out.okayset.map { meta, dir ->
-                def pubids_file = file("${dir}/*.pubids", checkIfExists: true)
+                def pubids_file = file("${dir}/*.pubids", checkIfExists: true, type: 'file')
                 return [ meta, pubids_file ]}
+            ch_pubids.view()
+            ch_pubids.ifEmpty {
+                error "ch_pubids is empty!"
+            }
             //
             // MODULE: TX2GENE
             //


### PR DESCRIPTION
The pipeline was running locally and on HPC, but failing tests on AWS even when run without fusion. 

- Checking the errors indicated that it was probably be due to how `ch_transcripts` and `ch_pubids` were defined. They were using glob patterns. The pipeline now uses a different approach to create these channels. This has been tested by launching the AWS test action manually (for `test` profile).
- Upon fixing the issue above, the Transrate module was still not running on AWS, as it required a temporary directory. Creation of this directory is now included in the module.
- When running the `full_test` on AWS, it needs to be run without fusion or with less logs. If we don't do this, the fusion log files become too large during the Trinity module and the step is reattempted again and again with higher resources. I've added resource limits for `full_test`, so that we don't end up requesting >1TB of memory with reattempts.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/denovotranscript/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/denovotranscript _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core pipelines lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
